### PR TITLE
Ensure JQueryUI is loaded.

### DIFF
--- a/public/scripts/admin.js
+++ b/public/scripts/admin.js
@@ -132,7 +132,7 @@ define('admin/plugins/tdwtfarticles', ['settings'], function(settings) {
 		});
 		
 	};
-	
+	app.loadJQueryUI();
 	return tdwtfArticles;
 });
 


### PR DESCRIPTION
The ACP interface wasn't working because NodeBB (now?) requires the plugin's code to ensure that JQueryUI is loaded via a call to `app.loadJQueryUI()`.

Fixes Issue #1 